### PR TITLE
Add content/conferenceFloor to the onEvent callback handler

### DIFF
--- a/lib/MCSBaseClient.js
+++ b/lib/MCSBaseClient.js
@@ -130,6 +130,8 @@ class MCSBaseClient extends MCSBase {
       case 'userJoined':
       case 'userLeft':
       case 'mediaConnected':
+      case 'conferenceFloorChanged':
+      case 'contentFloorChanged':
         identifier = roomId;
         break;
       case 'mediaDisconnected':

--- a/lib/MCSResponseClient.js
+++ b/lib/MCSResponseClient.js
@@ -476,15 +476,15 @@ class MCSResponseClient extends MCSBaseClient {
     /*
    * TODO docs
    */
-  conferenceFloorChanged (roomId, mediaId, params) {
+  conferenceFloorChanged (roomId, media, params) {
     if (!roomId || typeof (roomId) !== 'string') {
       throw (new Error('invalid roomId'));
     }
-    if (!mediaId || typeof (mediaId) !== 'string') {
-      throw (new Error('invalid mediaId'));
+    if (!media || typeof (media) !== 'object') {
+      throw (new Error('invalid media'));
     }
 
-    const message = new ConferenceFloorChanged(roomId, mediaId, params);
+    const message = new ConferenceFloorChanged(roomId, media, params);
 
     if (message) {
       this.send(message);
@@ -494,15 +494,15 @@ class MCSResponseClient extends MCSBaseClient {
   /*
    * TODO docs
    */
-  contentFloorChanged (roomId, mediaId, params) {
+  contentFloorChanged (roomId, media, params) {
     if (!roomId || typeof (roomId) !== 'string') {
       throw (new Error('invalid roomId'));
     }
-    if (!mediaId || typeof (mediaId) !== 'string') {
-      throw (new Error('invalid mediaId'));
+    if (!media || typeof (media) !== 'object') {
+      throw (new Error('invalid media'));
     }
 
-    const message = new ContentFloorChanged(roomId, mediaId, params);
+    const message = new ContentFloorChanged(roomId, media, params);
 
     if (message) {
       this.send(message);

--- a/lib/messages/conferenceFloor.js
+++ b/lib/messages/conferenceFloor.js
@@ -3,8 +3,8 @@ const MCSMessage = require('./MCSMessage');
 class conferenceFloor extends MCSMessage {
     constructor(roomId, mediaId, params) {
         super(C.CONFERENCE_FLOOR, null, params);
-        this.body.room_id = roomId;
-        this.body.media_id = mediaId
+        this.body.roomId = roomId;
+        this.body.mediaId = mediaId
     }
 }
-module.exports = conferenceFloor; 
+module.exports = conferenceFloor;

--- a/lib/messages/conferenceFloorChanged.js
+++ b/lib/messages/conferenceFloorChanged.js
@@ -4,10 +4,10 @@ const MCSMessage = require('./MCSMessage');
 const C = require('../constants');
 
 class conferenceFloorChanged extends MCSMessage {
-    constructor(roomId, mediaId, params) {
+    constructor(roomId, media, params) {
         super(C.CONFERENCE_FLOOR_CHANGED, null, params);
-        this.body.room_id = roomId;
-        this.body.media_id = mediaId
+        this.body.roomId = roomId;
+        this.body.media = media
     }
 }
 

--- a/lib/messages/contentFloorChanged.js
+++ b/lib/messages/contentFloorChanged.js
@@ -4,10 +4,10 @@ const MCSMessage = require('./MCSMessage');
 const C = require('../constants');
 
 class contentFloorChanged extends MCSMessage {
-    constructor(roomId, mediaId, params) {
+    constructor(roomId, media, params) {
         super(C.CONTENT_FLOOR_CHANGED, null, params);
-        this.body.room_id = roomId;
-        this.body.media_id = mediaId
+        this.body.roomId = roomId;
+        this.body.media = media;
     }
 }
 

--- a/lib/messages/getConferenceFloor.js
+++ b/lib/messages/getConferenceFloor.js
@@ -6,8 +6,8 @@ const C = require('../constants');
 class getConferenceFloor extends MCSMessage {
     constructor(roomId, mediaId) {
         super(C.GET_CONFERENCE_FLOOR);
-        this.body.room_id = roomId;
-        this.body.media_id = mediaId
+        this.body.roomId = roomId;
+        this.body.mediaId = mediaId
     }
 }
 

--- a/lib/messages/getContentFloor.js
+++ b/lib/messages/getContentFloor.js
@@ -6,8 +6,8 @@ const C = require('../constants');
 class getContentFloor extends MCSMessage {
     constructor(roomId, mediaId) {
         super(C.GET_CONTENT_FLOOR);
-        this.body.room_id = roomId;
-        this.body.media_id = mediaId
+        this.body.roomId = roomId;
+        this.body.mediaId = mediaId
     }
 }
 

--- a/lib/messages/releaseConferenceFloor.js
+++ b/lib/messages/releaseConferenceFloor.js
@@ -6,8 +6,8 @@ const C = require('../constants');
 class releaseConferenceFloor extends MCSMessage {
     constructor(roomId, mediaId) {
         super(C.RELEASE_CONFERENCE_FLOOR);
-        this.body.room_id = roomId
-        this.body.media_id = mediaId;
+        this.body.roomId = roomId
+        this.body.mediaId = mediaId;
     }
 }
 

--- a/lib/messages/releaseContentFloor.js
+++ b/lib/messages/releaseContentFloor.js
@@ -6,8 +6,8 @@ const C = require('../constants');
 class releaseContentFloor extends MCSMessage {
     constructor(roomId, mediaId) {
         super(C.RELEASE_CONTENT_FLOOR);
-        this.body.room_id = roomId
-        this.body.media_id = mediaId;
+        this.body.roomId = roomId
+        this.body.mediaId = mediaId;
     }
 }
 

--- a/lib/messages/setConferenceFloor.js
+++ b/lib/messages/setConferenceFloor.js
@@ -6,8 +6,8 @@ const C = require('../constants');
 class setConferenceFloor extends MCSMessage {
   constructor(roomId, mediaId) {
     super(C.SET_CONFERENCE_FLOOR);
-    this.body.room_id = roomId
-    this.body.media_id = mediaId;
+    this.body.roomId = roomId
+    this.body.mediaId = mediaId;
   }
 }
 

--- a/lib/messages/setContentFloor.js
+++ b/lib/messages/setContentFloor.js
@@ -6,8 +6,8 @@ const C = require('../constants');
 class setContentFloor extends MCSMessage {
     constructor(roomId, mediaId) {
         super(C.SET_CONTENT_FLOOR);
-        this.body.room_id = roomId
-        this.body.media_id = mediaId;
+        this.body.roomId = roomId
+        this.body.mediaId = mediaId;
     }
 }
 


### PR DESCRIPTION
Also standardized all content/conference floor message parameter naming
and changed their return where `mediaId` was used to use a `mediaInfo` state object
instead.