### PR TITLE
Remade the floor messages

### DIFF
--- a/lib/MCSClient.js
+++ b/lib/MCSClient.js
@@ -279,21 +279,20 @@ class MCSClient extends MCSBaseClient {
   /**
    *
    * @param {String} roomId
-   * @param {String} mediaId
    */
   getConferenceFloor (roomId) {
     if (!roomId || typeof(roomId) !== 'string') {
       throw new Error('Invalid roomId');
     }
 
-    const message = new GetConferenceFloorMessage(roomId)
+    const message = new GetConferenceFloorMessage(roomId);
+
     if (message) {
       return this.deferTransaction(message)
     }
   }
 
-    /**
-   *
+  /**
    * @param {String} roomId
    */
   getContentFloor (roomId) {
@@ -301,14 +300,14 @@ class MCSClient extends MCSBaseClient {
       throw new Error('Invalid roomId');
     }
 
-    const message = new GetContentFloorMessage(roomId)
+    const message = new GetContentFloorMessage(roomId);
+
     if (message) {
       return this.deferTransaction(message)
     }
   }
 
   /**
-   *
    * @param {String} roomId
    * @param {String} mediaId
    */
@@ -320,7 +319,8 @@ class MCSClient extends MCSBaseClient {
       throw new Error('Invalid mediaId');
     }
 
-    const message = new SetConferenceFloorMessage(roomId, mediaId)
+    const message = new SetConferenceFloorMessage(roomId, mediaId);
+
     if (message) {
       return this.deferTransaction(message)
     }
@@ -339,7 +339,8 @@ class MCSClient extends MCSBaseClient {
       throw new Error('Invalid mediaId');
     }
 
-    const message = new SetContentFloorMessage(roomId, mediaId)
+    const message = new SetContentFloorMessage(roomId, mediaId);
+
     if (message) {
       return this.deferTransaction(message)
     }
@@ -348,36 +349,29 @@ class MCSClient extends MCSBaseClient {
   /**
    *
    * @param {String} roomId
-   * @param {String} mediaId
    */
-  releaseContentFloor (roomId, mediaId) {
+  releaseContentFloor (roomId) {
     if (!roomId || typeof(roomId) !== 'string') {
       throw new Error('Invalid roomId');
     }
-    if (!mediaId || typeof(mediaId) !== 'string') {
-      throw new Error('Invalid mediaId');
-    }
 
-    const message = new ReleaseContentFloorMessage(roomId, mediaId)
+    const message = new ReleaseContentFloorMessage(roomId);
+
     if (message) {
       return this.deferTransaction(message)
     }
   }
 
   /**
-   *
    * @param {String} roomId
-   * @param {String} mediaId
    */
-  releaseConferenceFloor (roomId, mediaId) {
+  releaseConferenceFloor (roomId) {
     if (!roomId || typeof(roomId) !== 'string') {
       throw new Error('Invalid roomId');
     }
-    if (!mediaId || typeof(mediaId) !== 'string') {
-      throw new Error('Invalid mediaId');
-    }
 
-    const message = new ReleaseConferenceFloorMessage(roomId, mediaId)
+    const message = new ReleaseConferenceFloorMessage(roomId);
+
     if (message) {
       return this.deferTransaction(message)
     }

--- a/lib/MCSResponseClient.js
+++ b/lib/MCSResponseClient.js
@@ -473,76 +473,112 @@ class MCSResponseClient extends MCSBaseClient {
     }
   }
 
-    /*
-   * TODO docs
-   */
-  conferenceFloorChanged (roomId, media, params) {
-    if (!roomId || typeof (roomId) !== 'string') {
-      throw (new Error('invalid roomId'));
-    }
-    if (!media || typeof (media) !== 'object') {
-      throw (new Error('invalid media'));
-    }
-
-    const message = new ConferenceFloorChanged(roomId, media, params);
-
-    if (message) {
-      this.send(message);
-    }
-  }
-
   /*
-   * TODO docs
+   * @param {String} roomId
+   * @param {object} params
    */
-  contentFloorChanged (roomId, media, params) {
+  conferenceFloorChanged (roomId, params = {}) {
+    const { floor, previousFloor } = params;
+
     if (!roomId || typeof (roomId) !== 'string') {
       throw (new Error('invalid roomId'));
     }
-    if (!media || typeof (media) !== 'object') {
-      throw (new Error('invalid media'));
+
+    if (floor && typeof (floor) !== 'object') {
+      throw (new Error('invalid floor media'));
     }
 
-    const message = new ContentFloorChanged(roomId, media, params);
+    if (previousFloor && typeof (previousFloor) !== 'object') {
+      throw (new Error('invalid previousFloor'));
+    }
+
+    const message = new ConferenceFloorChanged(roomId, floor, previousFloor, params);
 
     if (message) {
       this.send(message);
     }
   }
 
-    /*
-   * TODO docs
+  /**
+   * @param {String} roomId
+   * @param {object} params
    */
-  conferenceFloor(roomId, mediaId, params) {
+  contentFloorChanged (roomId, params = {}) {
+    const { floor, previousFloor } = params;
+
     if (!roomId || typeof (roomId) !== 'string') {
       throw (new Error('invalid roomId'));
     }
-    if (!mediaId || typeof (mediaId) !== 'string') {
-      throw (new Error('invalid mediaId'));
+
+    if (floor && typeof (floor) !== 'object') {
+      throw (new Error('invalid floor media'));
     }
-    const message = new ConferenceFloor(roomId, mediaId, params);
+
+    if (previousFloor && typeof (previousFloor) !== 'object') {
+      throw (new Error('invalid previousFloor'));
+    }
+
+    const message = new ContentFloorChanged(roomId, floor, previousFloor, params);
+
     if (message) {
       this.send(message);
     }
   }
 
-    /*
-   * TODO docs
+  /**
+   * @param {String} roomId
+   * @param {object} params
    */
-  contentFloor(roomId, mediaId, params) {
+  conferenceFloor(roomId, floor, params) {
+    const { floor, previousFloor } = params;
+
     if (!roomId || typeof (roomId) !== 'string') {
       throw (new Error('invalid roomId'));
     }
-    if (!mediaId || typeof (mediaId) !== 'string') {
-      throw (new Error('invalid mediaId'));
+
+    if (floor && typeof (floor) !== 'object') {
+      throw (new Error('invalid floor media'));
     }
-    const message = new ContentFloor(roomId, mediaId, params);
+
+    if (previousFloor && typeof (previousFloor) !== 'object') {
+      throw (new Error('invalid previousFloor'));
+    }
+
+    const message = new ConferenceFloor(roomId, floor, previousFloor, params);
     if (message) {
       this.send(message);
     }
   }
 
-  /*
-   * TODO docs
+  /**
+   * @param {String} roomId
+   * @param {object} params
+   */
+  contentFloor (roomId, params) {
+    const { floor, previousFloor } = params;
+
+    if (!roomId || typeof (roomId) !== 'string') {
+      throw (new Error('invalid roomId'));
+    }
+
+    if (floor && typeof (floor) !== 'object') {
+      throw (new Error('invalid floor media'));
+    }
+
+    if (previousFloor && typeof (previousFloor) !== 'object') {
+      throw (new Error('invalid previousFloor'));
+    }
+
+    const message = new ContentFloor(roomId, floor, previousFloor, params);
+
+    if (message) {
+      this.send(message);
+    }
+  }
+
+  /**
+   * @param {String} recordingId The media ID of the recording session
+   * @param {object} params Additional optional parameters
    */
   recordingStarted(recordingId, params) {
     if (!recordingId || typeof (recordingId) !== 'string') {
@@ -555,8 +591,9 @@ class MCSResponseClient extends MCSBaseClient {
     }
   }
 
-  /*
-   * TODO docs
+  /**
+   * @param {String} recordingId The media ID of the recording session
+   * @param {object} params Additional optional parameters
    */
   recordingStopped(recordingId, params) {
     if (!recordingId || typeof (recordingId) !== 'string') {

--- a/lib/MCSResponseClient.js
+++ b/lib/MCSResponseClient.js
@@ -529,7 +529,7 @@ class MCSResponseClient extends MCSBaseClient {
    * @param {String} roomId
    * @param {object} params
    */
-  conferenceFloor(roomId, floor, params) {
+  conferenceFloor(roomId, params) {
     const { floor, previousFloor } = params;
 
     if (!roomId || typeof (roomId) !== 'string') {

--- a/lib/messages/conferenceFloor.js
+++ b/lib/messages/conferenceFloor.js
@@ -2,10 +2,11 @@
 const MCSMessage = require('./MCSMessage');
 
 class conferenceFloor extends MCSMessage {
-    constructor(roomId, mediaId, params) {
+    constructor(roomId, floor, previousFloor, params) {
         super(C.CONFERENCE_FLOOR, null, params);
         this.body.roomId = roomId;
-        this.body.mediaId = mediaId
+        this.body.floor = floor;
+        this.body.previousFloor = previousFloor;
     }
 }
 

--- a/lib/messages/conferenceFloorChanged.js
+++ b/lib/messages/conferenceFloorChanged.js
@@ -4,10 +4,11 @@ const MCSMessage = require('./MCSMessage');
 const C = require('../constants');
 
 class conferenceFloorChanged extends MCSMessage {
-    constructor(roomId, media, params) {
+    constructor(roomId, floor, previousFloor, params) {
         super(C.CONFERENCE_FLOOR_CHANGED, null, params);
         this.body.roomId = roomId;
-        this.body.media = media
+        this.body.floor = floor;
+        this.body.previousFloor = previousFloor;
     }
 }
 

--- a/lib/messages/contentFloor.js
+++ b/lib/messages/contentFloor.js
@@ -4,10 +4,11 @@ const MCSMessage = require('./MCSMessage');
 const C = require('../constants');
 
 class contentFloor extends MCSMessage {
-    constructor(roomId, mediaId, params) {
+    constructor(roomId, floor, previousFloor, params) {
         super(C.CONTENT_FLOOR, null, params);
         this.body.roomId  = roomId;
-        this.body.mediaId = mediaId
+        this.body.floor = floor;
+        this.body.previousFloor = previousFloor;
     }
 }
 

--- a/lib/messages/contentFloorChanged.js
+++ b/lib/messages/contentFloorChanged.js
@@ -4,10 +4,11 @@ const MCSMessage = require('./MCSMessage');
 const C = require('../constants');
 
 class contentFloorChanged extends MCSMessage {
-    constructor(roomId, media, params) {
+    constructor(roomId, floor, previousFloor, params) {
         super(C.CONTENT_FLOOR_CHANGED, null, params);
         this.body.roomId = roomId;
-        this.body.media = media;
+        this.body.floor = floor;
+        this.body.previousFloor = previousFloor;
     }
 }
 

--- a/lib/messages/releaseConferenceFloor.js
+++ b/lib/messages/releaseConferenceFloor.js
@@ -7,7 +7,6 @@ class releaseConferenceFloor extends MCSMessage {
     constructor(roomId, mediaId) {
         super(C.RELEASE_CONFERENCE_FLOOR);
         this.body.roomId = roomId
-        this.body.mediaId = mediaId;
     }
 }
 

--- a/lib/messages/releaseContentFloor.js
+++ b/lib/messages/releaseContentFloor.js
@@ -7,7 +7,6 @@ class releaseContentFloor extends MCSMessage {
     constructor(roomId, mediaId) {
         super(C.RELEASE_CONTENT_FLOOR);
         this.body.roomId = roomId
-        this.body.mediaId = mediaId;
     }
 }
 


### PR DESCRIPTION
- Conference and content floor members are now standardized;
- The floors commands now include the previous floor in their info along with the current floor and carry media info objects instead of ids;
- Turned the `floor` and `previousFloor` into optional parameters. If there are none of such in the media controller, the response will simply not include those keys in the body;
- Also removed the need of passing the floor id in the release methods;
- Added some of the missing method docs.